### PR TITLE
Parallelize profile requests

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -27,6 +27,12 @@ Strategy.prototype.userProfile = function(accessToken, done) {
   //LinkedIn uses a custom name for the access_token parameter
   this._oauth2.setAccessTokenName("oauth2_access_token");
 
+
+  var profile = { provider: 'linkedin' };
+  var loadedProfile = false;
+  var loadedEmail = false;
+  var cbCalledWithError = false;
+
   this._oauth2.get(this.profileUrl, accessToken, function (err, body, res) {
     try {
       if (err) {
@@ -34,8 +40,6 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       }
 
       var json = JSON.parse(body);
-
-      var profile = { provider: 'linkedin' };
 
       profile.id = json.id;
 
@@ -66,45 +70,62 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       profile._profileRaw = body;
       profile._profileJson = json;
 
+      loadedProfile = true;
+
       if (!this.options.scope.includes('r_emailaddress')) {
-        return done(null, profile);
+        loadedEmail = true;
       }
 
-      this._oauth2.get(this.emailUrl, accessToken, function (err, body, res) {
-        try {
-          if (err) {
-            throw new InternalOAuthError('failed to fetch user email', err);
-          }
-
-          var json = JSON.parse(body);
-
-          if (
-            json.elements &&
-            json.elements.length > 0
-          ) {
-            profile.emails = json.elements.reduce(function (memo, el) {
-              if (el['handle~'] && el['handle~'].emailAddress) {
-                memo.push({
-                  value: el['handle~'].emailAddress
-                });
-              }
-              return memo;
-            }, []);
-          }
-
-          profile._emailRaw = body;
-          profile._emailJson = json;
-
-          done(null, profile);
-        } catch (e) {
-          console.log(e);
-          done(e);
-        }
-      }.bind(this));
+      if (loadedEmail) {
+        return done(null, profile);
+      }
     } catch(e) {
-      done(e);
+      if (!cbCalledWithError) {
+        cbCalledWithError = true;
+        done(e);
+      }
     }
   }.bind(this));
+
+  if (this.options.scope.includes('r_emailaddress')) {
+    this._oauth2.get(this.emailUrl, accessToken, function (err, body, res) {
+      try {
+        if (err) {
+          throw new InternalOAuthError('failed to fetch user email', err);
+        }
+
+        var json = JSON.parse(body);
+
+        if (
+          json.elements &&
+          json.elements.length > 0
+        ) {
+          profile.emails = json.elements.reduce(function (memo, el) {
+            if (el['handle~'] && el['handle~'].emailAddress) {
+              memo.push({
+                value: el['handle~'].emailAddress
+              });
+            }
+            return memo;
+          }, []);
+        }
+
+        profile._emailRaw = body;
+        profile._emailJson = json;
+
+        loadedEmail = true;
+
+        if (loadedProfile) {
+          done(null, profile);
+        }
+      } catch (e) {
+        if (!cbCalledWithError) {
+          cbCalledWithError = true;
+          done(e);
+        }
+      }
+    }.bind(this));
+  }
 }
 
 

--- a/test/strategy.tests.js
+++ b/test/strategy.tests.js
@@ -83,7 +83,7 @@ describe('LinkedIn Strategy', function () {
     context('when error occurs', function () {
       before(function () {
         nock('https://api.linkedin.com')
-          .get('/v2/.*')
+          .get(/v2\/.*/)
           .reply(500)
       });
 


### PR DESCRIPTION
When a client has requested the `r_emailaddress` scope from LinkedIn, then
we do one more request. Instead of firing the requests sequentially we should
make both of them at the same time and merge them upon their responses.

These requests take aprox. 1 second when run sequentially, so half a
second when they're run in parallel